### PR TITLE
Add the getAgeInYears method

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ if (cnp.isValid()) {
   console.log(cnp.getBirthPlace());
   console.log(cnp.getGender());              // default male | female
   console.log(cnp.getGender('M', 'F'));      // or set a custom value M | F
+  console.log(cnp.getAgeInYears());
   console.log(cnp.hasIdentityCard());        // if the age is grater than 14 years
   console.log(cnp.getSerialNumberFromCNP());
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,7 @@ const countyCode: { [key: string]: string } = {
  *   console.log(cnp.getBirthPlace());
  *   console.log(cnp.getGender());              // default male | female
  *   console.log(cnp.getGender('M', 'F'));      // or set a custom value M | F
+ *   console.log(cnp.getAgeInYears())
  *   console.log(cnp.hasIdentityCard());        // if the age is grater than 14 years
  *   console.log(cnp.getSerialNumberFromCNP());
  * }
@@ -164,14 +165,24 @@ export class CNP {
     return gender
   }
 
-  public hasIdentityCard(): boolean {
+  public getAgeInYears(): number | null {
     if (!this._isValid) {
-      return false
+      return null
     }
 
     const birthDate = moment(this.dateInput(), 'YYYY-MM-DD')
 
-    return Math.floor(moment(new Date()).diff(birthDate, 'years', true)) > 14
+    return Math.floor(moment(Date.now()).diff(this.getBirthDate(), 'years', true));
+  }
+
+  public hasIdentityCard(): boolean {
+    const ageInYears = this.getAgeInYears()
+
+    if (ageInYears === null) {
+      return false;
+    }
+
+    return ageInYears >= 14
   }
 
   public getSerialNumberFromCNP(): string {

--- a/src/tests/CNP.test.ts
+++ b/src/tests/CNP.test.ts
@@ -1,32 +1,34 @@
 import { CNP } from '../index'
 import { describe, expect, test } from '@jest/globals'
 
+Date.now = () => new Date("2024-05-13T12:33:37.000Z").getTime();
+
 describe.each([
-  // cnp, isValid, birthDates, yy, birthPlace, gender, hasIdentityCard, serialNumber, cnpOut
-  ['123', false, 'Invalid date', 'Invalid date', null, '', false, '', 'Invalid CNP'],
-  ['x5110102441483', false, 'Invalid date', 'Invalid date', null, '', false, '', 'Invalid CNP'],
-  ['511010244x1483', false, 'Invalid date', 'Invalid date', null, '', false, '', 'Invalid CNP'],
-  ['5110102441483', true, '2011-01-02', '11', 'București - Sector 4', 'male', false, '148', '5110102441483'],
-  ['6140101070075', true, '2014-01-01', '14', 'Botoșani', 'female', false, '007', '6140101070075'],
-  ['3970908055828', true, '1897-09-08', '97', 'Bihor', 'male', true, '582', '3970908055828'],
-  ['2970702435244', true, '1997-07-02', '97', 'București - Sector 3', 'female', true, '524', '2970702435244'],
+  // cnp, isValid, birthDate, yy, birthPlace, gender, ageInYears, hasIdentityCard, serialNumber, cnpOut
+  ['123', false, 'Invalid date', 'Invalid date', null, '', null, false, '', 'Invalid CNP'],
+  ['x5110102441483', false, 'Invalid date', 'Invalid date', null, '', null, false, '', 'Invalid CNP'],
+  ['511010244x1483', false, 'Invalid date', 'Invalid date', null, '', null, false, '', 'Invalid CNP'],
+  ['5110102441483', true, '2011-01-02', '11', 'București - Sector 4', 'male', 13, false, '148', '5110102441483'],
+  ['6140101070075', true, '2014-01-01', '14', 'Botoșani', 'female', 10, false, '007', '6140101070075'],
+  ['3970908055828', true, '1897-09-08', '97', 'Bihor', 'male', 126, true, '582', '3970908055828'],
+  ['2970702435244', true, '1997-07-02', '97', 'București - Sector 3', 'female', 26, true, '524', '2970702435244'],
   // he was not born
-  ['6990504015905', true, '2099-05-04', '99', 'Alba', 'female', false, '590', '6990504015905'],
+  ['6990504015905', true, '2099-05-04', '99', 'Alba', 'female', -75, false, '590', '6990504015905'],
   // resident
-  ['9990504015919', true, '1999-05-04', '99', 'Alba', '', true, '591', '9990504015919'],
+  ['9990504015919', true, '1999-05-04', '99', 'Alba', '', 25, true, '591', '9990504015919'],
   // check sum
-  ['1850611212751', true, '1985-06-11', '85', 'Ialomița', 'male', true, '275', '1850611212751'],
+  ['1850611212751', true, '1985-06-11', '85', 'Ialomița', 'male', 38, true, '275', '1850611212751'],
 ])(
   '.try to validate CNP %s',
-  (cnp, isValid, birthDates, yy, birthPlace, gender, hasIdentityCard, serialNumber, cnpOut) => {
+  (cnp, isValid, birthDate, yy, birthPlace, gender, ageInYears, hasIdentityCard, serialNumber, cnpOut) => {
     const cnpObj = new CNP(cnp)
 
     test(`isValid() method return '${isValid}'`, () => {
       expect(cnpObj.isValid()).toBe(isValid)
     })
 
-    test(`getBirthDate() method return '${birthDates}'`, () => {
-      expect(cnpObj.getBirthDate()).toBe(birthDates)
+    test(`getBirthDate() method return '${birthDate}'`, () => {
+      expect(cnpObj.getBirthDate()).toBe(birthDate)
     })
 
     test(`getBirthPlace() method return '${birthPlace}'`, () => {
@@ -35,6 +37,10 @@ describe.each([
 
     test(`getGender() method return '${gender}'`, () => {
       expect(cnpObj.getGender()).toBe(gender)
+    })
+
+    test(`getAgeInYears() method return '${ageInYears}'`, () => {
+      expect(cnpObj.getAgeInYears()).toBe(ageInYears)
     })
 
     test(`hasIdentityCard() method return '${hasIdentityCard}'`, () => {


### PR DESCRIPTION
I added the `getAgeInYears` method because I consider it useful.

On this occasion I fixed the following 2 problems:
- I fixed two tests that were going to fail in a year, respectively 3 years from now, because they used the date of the moment of execution, but the output values ​​were static.
- Before, the library considered that a person has an identity card from the age of 15, although the age should be 14. It was probably a typo, I changed it.